### PR TITLE
[feat/03]: add profiles, invoices & invoice_items models with FK…

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,62 @@ jobs:
 
 ---
 
+## 🗄️ Datenbankschema (Stand: Profile & Invoices)
+
+Das Backend nutzt **SQLite** mit [SQLModel](https://sqlmodel.tiangolo.com/).  
+Aktuell sind die folgenden Tabellen und Relationen definiert:
+
+## 🗄️ Datenbankschema (Stand: Profile & Invoices)
+
+Das Backend nutzt **SQLite** mit [SQLModel](https://sqlmodel.tiangolo.com/).  
+Aktuell sind die folgenden Tabellen und Relationen definiert:
+
+```mermaid
+erDiagram
+    CUSTOMER ||--o{ INVOICE : "hat"
+    PROFILE  ||--o{ INVOICE : "erstellt"
+    INVOICE  ||--o{ INVOICE_ITEM : "enthält"
+
+    CUSTOMER {
+        int id PK
+        string name
+        string address "nullable"
+    }
+
+    PROFILE {
+        int id PK
+        string name
+        string address
+        string bank_data "nullable"
+        string tax_number "nullable"
+    }
+
+    INVOICE {
+        int id PK
+        string number
+        string date
+        int customer_id FK
+        int profile_id FK
+        float total_amount
+    }
+
+    INVOICE_ITEM {
+        int id PK
+        int invoice_id FK
+        int quantity
+        string description
+        float price
+    }
+  ```
+  ### Beschreibung 
+
+  - Customer: Stammdaten der Kunden (1:n zu Invoices)
+  - Profile: Absender-Profile, z. B. verschiedene Geschäftseinheiten (1:n zu Invoices)
+  - Invoice: Rechnung mit eindeutiger Nummer, Datum und Verknüpfung zu Customer und Profile
+  - InvoiceItem: Positionen einer Rechnung (z. B. Dienstleistungen, Produkte)
+
+---
+
 ## 📚 Referenzen (Docs)
 - FastAPI: https://fastapi.tiangolo.com  
 - SQLModel: https://sqlmodel.tiangolo.com  

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,1 +1,4 @@
 from .customer import Customer  # noqa: F401
+from .profile import Profile  # noqa: F401
+from .invoice import Invoice  # noqa: F401
+from .invoice_item import Invoice_Item  # noqa: F401

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,4 +1,4 @@
 from .customer import Customer  # noqa: F401
-from .profile import Profile  # noqa: F401
 from .invoice import Invoice  # noqa: F401
 from .invoice_item import Invoice_Item  # noqa: F401
+from .profile import Profile  # noqa: F401

--- a/backend/models/invoice.py
+++ b/backend/models/invoice.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from sqlmodel import Field, SQLModel
 
+
 class Invoice(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     number: str

--- a/backend/models/invoice.py
+++ b/backend/models/invoice.py
@@ -1,0 +1,11 @@
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+class Invoice(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    number: str
+    date: str
+    customer_id: int = Field(foreign_key="customer.id")
+    profile_id: int = Field(foreign_key="profile.id")
+    total_amount: float

--- a/backend/models/invoice_item.py
+++ b/backend/models/invoice_item.py
@@ -1,0 +1,10 @@
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+class Invoice_Item(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    invoice_id: int = Field(foreign_key="invoice.id")
+    quantity: int
+    description: str
+    price: float

--- a/backend/models/invoice_item.py
+++ b/backend/models/invoice_item.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from sqlmodel import Field, SQLModel
 
+
 class Invoice_Item(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     invoice_id: int = Field(foreign_key="invoice.id")

--- a/backend/models/profile.py
+++ b/backend/models/profile.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from sqlmodel import Field, SQLModel
 
+
 class Profile(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str

--- a/backend/models/profile.py
+++ b/backend/models/profile.py
@@ -1,0 +1,10 @@
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+class Profile(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    address: str
+    bank_data: Optional[str] = None
+    tax_number: Optional[str] = None

--- a/backend/tests/test_invoices_schema.py
+++ b/backend/tests/test_invoices_schema.py
@@ -2,7 +2,7 @@
 import pytest
 from sqlalchemy import event
 from sqlalchemy.exc import IntegrityError
-from sqlmodel import SQLModel, create_engine, Session, select
+from sqlmodel import Session, SQLModel, create_engine, select
 
 from database import init_db
 
@@ -51,9 +51,9 @@ def test_insert_with_foreign_keys(session: Session):
     """
     # Lazy-Import, damit Tests schon vor Implementierung geladen werden
     from models.customer import Customer
-    from models.profile import Profile
     from models.invoice import Invoice
     from models.invoice_item import Invoice_Item
+    from models.profile import Profile
 
     cust = Customer(name="Max Mustermann")
     prof = Profile(
@@ -94,7 +94,9 @@ def test_insert_with_foreign_keys(session: Session):
     assert loaded_inv.customer_id == cust.id
     assert loaded_inv.profile_id == prof.id
 
-    items = session.exec(select(Invoice_Item).where(Invoice_Item.invoice_id == inv.id)).all()
+    items = session.exec(
+        select(Invoice_Item).where(Invoice_Item.invoice_id == inv.id)
+    ).all()
     assert len(items) == 1
     assert items[0].description == "Haarschnitt Damen"
 
@@ -111,7 +113,7 @@ def test_foreign_key_enforced(session: Session):
         number="25|99999",
         date="2025-09-01",
         customer_id=999999,  # existiert nicht
-        profile_id=999999,   # existiert nicht
+        profile_id=999999,  # existiert nicht
         total_amount=10.0,
     )
     session.add(bad_invoice)

--- a/backend/tests/test_invoices_schema.py
+++ b/backend/tests/test_invoices_schema.py
@@ -1,0 +1,120 @@
+# backend/tests/test_invoices_schema.py
+import pytest
+from sqlalchemy import event
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import SQLModel, create_engine, Session, select
+
+from database import init_db
+
+
+@pytest.fixture(scope="session")
+def engine():
+    # Eine gemeinsame In-Memory-DB für alle Tests in dieser Datei
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+
+    # SQLite: FK-Enforcement aktivieren
+    @event.listens_for(engine, "connect")
+    def _enable_sqlite_fk(dbapi_connection, connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    # Tabellen laut Models anlegen (wird nach Implementierung grün)
+    init_db(engine)
+    return engine
+
+
+@pytest.fixture
+def session(engine):
+    with Session(engine) as s:
+        yield s
+
+
+def test_tables_exist_in_metadata():
+    # Prüft, ob die Tabellen-Namen in den SQLModel-Metadaten registriert sind
+    tables = SQLModel.metadata.tables
+    assert "profile" in tables
+    assert "invoice" in tables
+    assert "invoice_item" in tables
+
+
+def test_insert_with_foreign_keys(session: Session):
+    """
+    Happy Path:
+    - Customer + Profile anlegen
+    - Invoice referenziert beide
+    - Invoice_Item referenziert Invoice
+    - Alles committen und wieder auslesen
+    """
+    # Lazy-Import, damit Tests schon vor Implementierung geladen werden
+    from models.customer import Customer
+    from models.profile import Profile
+    from models.invoice import Invoice
+    from models.invoice_item import Invoice_Item
+
+    cust = Customer(name="Max Mustermann")
+    prof = Profile(
+        name="Salon Sunshine",
+        address="Hauptstr. 1",
+        bank_data="DE00 1234 5678 9000 0000 00",
+        tax_number="12/345/67890",
+    )
+    session.add(cust)
+    session.add(prof)
+    session.commit()
+    session.refresh(cust)
+    session.refresh(prof)
+
+    inv = Invoice(
+        number="25|00001",
+        date="2025-09-01",
+        customer_id=cust.id,
+        profile_id=prof.id,
+        total_amount=49.90,
+    )
+    session.add(inv)
+    session.commit()
+    session.refresh(inv)
+
+    item = Invoice_Item(
+        invoice_id=inv.id,
+        quantity=1,
+        description="Haarschnitt Damen",
+        price=49.90,
+    )
+    session.add(item)
+    session.commit()
+    session.refresh(item)
+
+    # Verifizieren
+    loaded_inv = session.exec(select(Invoice).where(Invoice.id == inv.id)).one()
+    assert loaded_inv.customer_id == cust.id
+    assert loaded_inv.profile_id == prof.id
+
+    items = session.exec(select(Invoice_Item).where(Invoice_Item.invoice_id == inv.id)).all()
+    assert len(items) == 1
+    assert items[0].description == "Haarschnitt Damen"
+
+
+def test_foreign_key_enforced(session: Session):
+    """
+    Negative Case:
+    Versuche eine Invoice mit nicht existierender customer_id/profile_id anzulegen.
+    Erwartet: IntegrityError (FK-Verletzung)
+    """
+    from models.invoice import Invoice
+
+    bad_invoice = Invoice(
+        number="25|99999",
+        date="2025-09-01",
+        customer_id=999999,  # existiert nicht
+        profile_id=999999,   # existiert nicht
+        total_amount=10.0,
+    )
+    session.add(bad_invoice)
+    with pytest.raises(IntegrityError):
+        session.commit()
+    session.rollback()


### PR DESCRIPTION
## Zusammenfassung
Dieses PR fügt die weiteren Datenbanktabellen **profiles**, **invoices** und **invoice_items** hinzu.  
Relationen zwischen Customers ↔ Invoices sowie Profiles ↔ Invoices sind via Foreign Keys abgebildet.  
Das Schema wurde im README ergänzt (Mermaid-Diagramm).  

## Verwandte Issues
Closes #7 

## Änderungen
- Model `Profile` angelegt
- Model `Invoice` mit `customer_id` & `profile_id` als FK
- Model `InvoiceItem` mit FK auf `Invoice`
- Tests `test_invoices_schema.py` für Inserts + FK-Verletzungen
- README: DB-Schema (Mermaid-Diagramm + Erklärung)

## Wie testen?
1. Backend starten (`uvicorn main:app --reload`)
2. `pytest -vv` ausführen  
3. Erwartet: Alle Tests grün, insbesondere FK-Tests (`test_invoices_schema.py`)

## Checkliste (DoD)
- [x] Tabellen `profiles`, `invoices`, `invoice_items` existieren
- [x] Relationen via Foreign Keys gesetzt
- [x] Models dokumentiert
- [x] Tests grün (FK + Inserts)
- [x] Readme mit DB-Schema aktualisiert
- [ ] Alembic optional vorbereitet (später)
