### PR TITLE
Feat/03 crud profiles

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from database import init_db
-from routers import customers, health
+from routers import customers, health, profiles
 
 
 @asynccontextmanager
@@ -25,3 +25,4 @@ app = FastAPI(
 
 app.include_router(health.router)
 app.include_router(customers.router)
+app.include_router(profiles.router)

--- a/backend/routers/profiles.py
+++ b/backend/routers/profiles.py
@@ -1,0 +1,55 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import Session, select
+
+from database import get_session
+from models import Profile
+
+router = APIRouter(prefix="/profiles", tags=["profiles"])
+
+
+@router.post("/", response_model=Profile, status_code=201)
+def create_profile(profile: Profile, session: Session = Depends(get_session)):
+    if not profile.name or not profile.address:
+        raise HTTPException(status_code=400, detail="Missing required fields")
+    session.add(profile)
+    session.commit()
+    session.refresh(profile)
+    return profile
+
+@router.get("/", response_model=list[Profile])
+def list_profiles(session: Session = Depends(get_session)):
+    return session.exec(select(Profile)).all()
+
+@router.get("/{profile_id}", response_model=Profile)
+def get_profile(profile_id: int, session: Session = Depends(get_session)):
+    profile = session.get(Profile, profile_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return profile
+
+@router.put("/{profile_id}", response_model=Profile)
+def update_profile(
+    profile_id: int,
+    updated_profile: Profile,
+    session: Session = Depends(get_session),
+):
+    profile = session.get(Profile, profile_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    profile.name = updated_profile.name
+    profile.address = updated_profile.address
+    profile.bank_data = updated_profile.bank_data
+    profile.tax_number = updated_profile.tax_number
+    session.add(profile)
+    session.commit()
+    session.refresh(profile)
+    return profile
+
+@router.delete("/{profile_id}", status_code=204)
+def delete_profile(profile_id: int, session: Session = Depends(get_session)):
+    profile = session.get(Profile, profile_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    session.delete(profile)
+    session.commit()
+    return None

--- a/backend/routers/profiles.py
+++ b/backend/routers/profiles.py
@@ -16,9 +16,11 @@ def create_profile(profile: Profile, session: Session = Depends(get_session)):
     session.refresh(profile)
     return profile
 
+
 @router.get("/", response_model=list[Profile])
 def list_profiles(session: Session = Depends(get_session)):
     return session.exec(select(Profile)).all()
+
 
 @router.get("/{profile_id}", response_model=Profile)
 def get_profile(profile_id: int, session: Session = Depends(get_session)):
@@ -26,6 +28,7 @@ def get_profile(profile_id: int, session: Session = Depends(get_session)):
     if not profile:
         raise HTTPException(status_code=404, detail="Profile not found")
     return profile
+
 
 @router.put("/{profile_id}", response_model=Profile)
 def update_profile(
@@ -44,6 +47,7 @@ def update_profile(
     session.commit()
     session.refresh(profile)
     return profile
+
 
 @router.delete("/{profile_id}", status_code=204)
 def delete_profile(profile_id: int, session: Session = Depends(get_session)):

--- a/backend/tests/test_profiles.py
+++ b/backend/tests/test_profiles.py
@@ -1,0 +1,66 @@
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+def test_create_profile():
+    response = client.post("/profiles/", json={"name": "Test Profile", "address": "123 Test Street"})
+    assert response.status_code == 201
+    assert response.json()["name"] == "Test Profile"
+    assert response.json()["address"] == "123 Test Street"
+
+def test_create_profile_with_optional_fields():
+    response = client.post("/profiles/", json={
+        "name": "Full Profile",
+        "address": "456 Full Street",
+        "bank_data": "DE89 3704 0044 0532 0130 00",
+        "tax_number": "123/456/78901"
+    })
+    assert response.status_code == 201
+    data = response.json()
+    assert data["bank_data"] == "DE89 3704 0044 0532 0130 00"
+    assert data["tax_number"] == "123/456/78901"
+    assert data["name"] == "Full Profile"
+    assert data["address"] == "456 Full Street"
+
+def test_get_profile():
+    # Erstellt ein Profil zum Abrufen
+    create_response = client.post("/profiles/", json={"name": "Get Profile", "address": "789 Get Street"})
+    profile_id = create_response.json()["id"]
+
+    response = client.get(f"/profiles/{profile_id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == profile_id
+    assert data["name"] == "Get Profile"
+    assert data["address"] == "789 Get Street"
+
+def test_get_profile_list():
+    response = client.get("/profiles/")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+
+def test_update_profile():
+    # Erstellt ein Profil zum Aktualisieren
+    create_response = client.post("/profiles/", json={"name": "Update Profile", "address": "123 Update Street"})
+    profile_id = create_response.json()["id"]
+
+    response = client.put(f"/profiles/{profile_id}", json={"name": "Updated Profile", "address": "456 Updated Street"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == profile_id
+    assert data["name"] == "Updated Profile"
+    assert data["address"] == "456 Updated Street"
+
+def test_delete_profile():
+    # Erstellt ein Profil zum Löschen
+    create_response = client.post("/profiles/", json={"name": "Delete Profile", "address": "123 Delete Street"})
+    profile_id = create_response.json()["id"]
+
+    response = client.delete(f"/profiles/{profile_id}")
+    assert response.status_code == 204
+
+    response = client.get(f"/profiles/{profile_id}")
+    assert response.status_code == 404

--- a/backend/tests/test_profiles.py
+++ b/backend/tests/test_profiles.py
@@ -4,19 +4,26 @@ from main import app
 
 client = TestClient(app)
 
+
 def test_create_profile():
-    response = client.post("/profiles/", json={"name": "Test Profile", "address": "123 Test Street"})
+    response = client.post(
+        "/profiles/", json={"name": "Test Profile", "address": "123 Test Street"}
+    )
     assert response.status_code == 201
     assert response.json()["name"] == "Test Profile"
     assert response.json()["address"] == "123 Test Street"
 
+
 def test_create_profile_with_optional_fields():
-    response = client.post("/profiles/", json={
-        "name": "Full Profile",
-        "address": "456 Full Street",
-        "bank_data": "DE89 3704 0044 0532 0130 00",
-        "tax_number": "123/456/78901"
-    })
+    response = client.post(
+        "/profiles/",
+        json={
+            "name": "Full Profile",
+            "address": "456 Full Street",
+            "bank_data": "DE89 3704 0044 0532 0130 00",
+            "tax_number": "123/456/78901",
+        },
+    )
     assert response.status_code == 201
     data = response.json()
     assert data["bank_data"] == "DE89 3704 0044 0532 0130 00"
@@ -24,9 +31,12 @@ def test_create_profile_with_optional_fields():
     assert data["name"] == "Full Profile"
     assert data["address"] == "456 Full Street"
 
+
 def test_get_profile():
     # Erstellt ein Profil zum Abrufen
-    create_response = client.post("/profiles/", json={"name": "Get Profile", "address": "789 Get Street"})
+    create_response = client.post(
+        "/profiles/", json={"name": "Get Profile", "address": "789 Get Street"}
+    )
     profile_id = create_response.json()["id"]
 
     response = client.get(f"/profiles/{profile_id}")
@@ -36,27 +46,37 @@ def test_get_profile():
     assert data["name"] == "Get Profile"
     assert data["address"] == "789 Get Street"
 
+
 def test_get_profile_list():
     response = client.get("/profiles/")
     assert response.status_code == 200
     data = response.json()
     assert isinstance(data, list)
 
+
 def test_update_profile():
     # Erstellt ein Profil zum Aktualisieren
-    create_response = client.post("/profiles/", json={"name": "Update Profile", "address": "123 Update Street"})
+    create_response = client.post(
+        "/profiles/", json={"name": "Update Profile", "address": "123 Update Street"}
+    )
     profile_id = create_response.json()["id"]
 
-    response = client.put(f"/profiles/{profile_id}", json={"name": "Updated Profile", "address": "456 Updated Street"})
+    response = client.put(
+        f"/profiles/{profile_id}",
+        json={"name": "Updated Profile", "address": "456 Updated Street"},
+    )
     assert response.status_code == 200
     data = response.json()
     assert data["id"] == profile_id
     assert data["name"] == "Updated Profile"
     assert data["address"] == "456 Updated Street"
 
+
 def test_delete_profile():
     # Erstellt ein Profil zum Löschen
-    create_response = client.post("/profiles/", json={"name": "Delete Profile", "address": "123 Delete Street"})
+    create_response = client.post(
+        "/profiles/", json={"name": "Delete Profile", "address": "123 Delete Street"}
+    )
     profile_id = create_response.json()["id"]
 
     response = client.delete(f"/profiles/{profile_id}")


### PR DESCRIPTION
## Zusammenfassung
Implementiert vollständiges CRUD für das Profile-Modell.  
Damit können Absender-Profile (z. B. verschiedene Geschäftsstellen) nun erstellt, gelesen, aktualisiert und gelöscht werden.

## Verwandte Issues
Closes #15 

## Änderungen
- Profile-Router mit Endpoints:
  - POST /profiles
  - GET /profiles
  - GET /profiles/{id}
  - PUT /profiles/{id}
  - DELETE /profiles/{id}
- Tests für alle Endpoints (`test_profiles.py`)
- README ergänzt (Profile CRUD dokumentiert)

## Wie testen?
1. Backend starten:
   ```bash
   cd backend
   uvicorn main:app --reload
   ```
2. Swagger öffnen: http://127.0.0.1:8000/docs
3. Manuell testen:
- Profile anlegen (POST)
- Profile abrufen (GET)
- Profile aktualisieren (PUT)
- Profile löschen (DELETE)
4. Tests laufen:
```bash 
pytest -vv
```

---

### ✅ **Checkliste (DoD)**  

```markdown
## Checkliste (DoD)
- [x] Funktionalität erfüllt (Akzeptanzkriterien)
- [x] Readme/Docs aktualisiert
- [x] Keine Secrets/Keys committed
- [x] Lint/Build grün
- [x] Manuelle Tests (happy path & edge cases)
- [ ] CORS geprüft (Dev/Prod)
- [ ] PDF erzeugt & visuell geprüft (nicht relevant hier)
- [ ] (optional) E-Rechnung Validierung dokumentiert
